### PR TITLE
Add AppIndicator/SysTray icon

### DIFF
--- a/src/fan.py
+++ b/src/fan.py
@@ -9,34 +9,31 @@ from PyQt5.QtCore import QTimer
 from PyQt5.QtGui import QDragEnterEvent, QDragMoveEvent, QDropEvent
 from PyQt5.QtWidgets import QApplication, QDialog, QFileDialog, QGraphicsScene, QListWidget, QMainWindow, QMessageBox
 
-from ui.gui import Ui_MainWindow
+from ui.gui import Ui_MainWindow, Ui_SysTrayIndicator
 
 VERSION = "v0.8.1"
 
 PROC_FAN = "/proc/acpi/ibm/fan"
 
 class MainWindow(QMainWindow, Ui_MainWindow):
-
     def __init__(self, app: QApplication):
         super().__init__()
         self.app = app
+        self.setupUi()
 
-        self.setupUi(self)
         self.label_3.setText(self.label_3.text().replace("$$$", VERSION))
 
         # buttons
-        self.button_set.clicked.connect(lambda: self.setFanSpeed(self.slider.value()))
-        self.button_auto.clicked.connect(lambda: self.setFanSpeed("auto"))
-        self.button_full.clicked.connect(lambda: self.setFanSpeed("full-speed"))
+        self.button_set.clicked.connect(lambda: app.setFanSpeed(self.slider.value()))
+        self.button_auto.clicked.connect(lambda: app.setFanSpeed("auto"))
+        self.button_full.clicked.connect(lambda: app.setFanSpeed("full-speed"))
 
-        # timer
-        self.updateTimer = QTimer(self)
-        self.updateTimer.timeout.connect(self.getTempInfo)
-        self.updateTimer.timeout.connect(self.getFanInfo)
-        self.updateTimer.start(1000)
-        self.updateTimer.timeout.emit()
+    def closeEvent(self, event):
+        event.ignore()
+        self.hide()
 
     def showErrorMSG(self, msg_str: str, title_msg="ERROR"):
+        self.appear()
         msg = QMessageBox()
         msg.setIcon(QMessageBox.Critical)
         msg.setText(msg_str)
@@ -44,7 +41,42 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         msg.setDefaultButton(QMessageBox.Close)
         msg.exec_()
 
-    def getTempInfo_old(self):
+    def appear(self):
+        self.center()
+        self.show()
+        self.raise_()
+        self.activateWindow()
+
+    def center(self):
+        qr = self.frameGeometry()
+        qr.moveCenter(
+            self.app.primaryScreen().availableGeometry().center())
+        self.move(qr.topLeft())
+
+
+class ThinkFanUI(QApplication, Ui_SysTrayIndicator):
+    def __init__(self, argv):
+        super().__init__(argv)
+        self.setApplicationVersion(VERSION)
+
+        self.mainWindow = MainWindow(self)
+        self.setupSysTrayIndicator()
+
+        self.updateTimer = QTimer(self)
+        self.updateTimer.timeout.connect(self.updateUI)
+        self.updateTimer.start(1000)
+        self.updateTimer.timeout.emit()
+
+        # self.mainWindow.appear()
+
+    def updateUI(self):
+        temp_info = self.getTempInfo()
+        fan_info = self.getFanInfo()
+        self.mainWindow.label_temp.setText(temp_info)
+        self.mainWindow.label_fan.setText(fan_info)
+        self.updateSysTrayIndicatorMenu()
+
+    def getTempInfo_json(self):
         """ Reads output of the "sensors" command """
 
         proc = subprocess.Popen(["sensors", "-j"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -69,7 +101,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         else:
             result = sErr.decode()
 
-        self.label_temp.setText(result)
+        return result
 
     def getTempInfo(self):
         """ Reads output of the "sensors" command """
@@ -88,13 +120,14 @@ class MainWindow(QMainWindow, Ui_MainWindow):
                 line = line.strip()
                 # print(line)
                 if tempRE.match(line):
+                    # if "CPU" in line:
+                    #     result = line
                     if "pci" not in line and "0.0" not in line:
                         result += line + "\n"
         else:
             result = sErr.decode()
 
-        self.label_temp.setText(result)
-        #print(result)
+        return result
 
     def getFanInfo(self):
         """ Parses the first 3 lines of output from /proc/acpi/ibm/fan """
@@ -114,7 +147,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         else:
             result = sErr.decode()
 
-        self.label_fan.setText(result)
+        return result
 
     def setFanSpeed(self, speed="auto"):
         """
@@ -128,22 +161,10 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             with open(PROC_FAN, "w+") as soc:
                 soc.write(f"level {speed}")
         except PermissionError:
-            self.showErrorMSG("Missing permissions! Please run as root.")
+            self.mainWindow.showErrorMSG("Missing permissions! Please run as root.")
         except FileNotFoundError:
-            self.showErrorMSG(f"{PROC_FAN} does not exist!")
-
-    def center(self):
-        qr = self.frameGeometry()
-        qr.moveCenter(
-            self.app.primaryScreen().availableGeometry().center())
-        self.move(qr.topLeft())
+            self.mainWindow.showErrorMSG(f"{PROC_FAN} does not exist!")
 
 if __name__ == "__main__":
-    app = QApplication(sys.argv)
-    app.setApplicationVersion(VERSION)
-
-    mainWindow = MainWindow(app)
-    mainWindow.center()
-    mainWindow.show()
-
+    app = ThinkFanUI(sys.argv)
     sys.exit(app.exec_())

--- a/src/fan.py
+++ b/src/fan.py
@@ -44,7 +44,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         msg.exec_()
 
     def appear(self):
-        self.center()
+        # self.center()
         self.show()
         self.raise_()
         self.activateWindow()
@@ -63,6 +63,7 @@ class ThinkFanUI(QApplication, QApp_SysTrayIndicator):
     def __init__(self, argv):
         super(QApplication, self).__init__(argv)
         self.setApplicationVersion(VERSION)
+        self.setApplicationDisplayName("ThinkFan UI")
 
         self.mainWindow = MainWindow(self)
 

--- a/src/fan.py
+++ b/src/fan.py
@@ -82,12 +82,14 @@ class ThinkFanUI(QApplication, QApp_SysTrayIndicator):
             self.mainWindow.appear()
 
     def updateUI(self):
-        temp_info = self.getTempInfo()
-        fan_info = self.getFanInfo()
+        temp_info, fan_info = None, None
         if self.mainWindow.isActiveWindow():
+            temp_info, fan_info = self.getTempInfo(), self.getFanInfo()
             self.mainWindow.label_temp.setText(temp_info)
             self.mainWindow.label_fan.setText(fan_info)
         if self.use_indicator and self.menu_visible:
+            temp_info = temp_info or self.getTempInfo()
+            fan_info = fan_info or self.getFanInfo()
             self.updateIndicatorMenu(temp_info, fan_info)
 
     def getTempInfo_json(self):

--- a/src/fan.py
+++ b/src/fan.py
@@ -80,21 +80,16 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         #print(sOut, sErr)
 
         if not sErr:
-            data = sOut.decode().split("\n")
+            lines = sOut.decode().split("\n")
             result = ""
-            tempRE = re.compile(r"^.+\Stemp")
+            tempRE = re.compile(r"^(\w+):\s+\+.*(°|C|F| +)$")
 
-            for i, line in enumerate(data):
+            for i, line in enumerate(lines):
+                line = line.strip()
+                # print(line)
                 if tempRE.match(line):
-                    i += 1
-                    while data[i] != "":
-                        if not "pci" in data[i].lower():
-                            result += data[i]
-                            result += "\n"
-
-                        i += 1
-                    else:
-                        break
+                    if "pci" not in line and "0.0" not in line:
+                        result += line + "\n"
         else:
             result = sErr.decode()
 

--- a/src/fan.py
+++ b/src/fan.py
@@ -9,7 +9,8 @@ from PyQt5.QtCore import QTimer
 from PyQt5.QtGui import QDragEnterEvent, QDragMoveEvent, QDropEvent
 from PyQt5.QtWidgets import QApplication, QDialog, QFileDialog, QGraphicsScene, QListWidget, QMainWindow, QMessageBox
 
-from ui.gui import Ui_MainWindow, Ui_SysTrayIndicator
+from ui.gui import Ui_MainWindow
+from ui.systray import QApp_SysTrayIndicator
 
 VERSION = "v0.8.1"
 
@@ -19,7 +20,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
     def __init__(self, app: QApplication):
         super().__init__()
         self.app = app
-        self.setupUi()
+        self.setupUi(self)
 
         self.label_3.setText(self.label_3.text().replace("$$$", VERSION))
 
@@ -54,7 +55,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self.move(qr.topLeft())
 
 
-class ThinkFanUI(QApplication, Ui_SysTrayIndicator):
+class ThinkFanUI(QApplication, QApp_SysTrayIndicator):
     def __init__(self, argv):
         super().__init__(argv)
         self.setApplicationVersion(VERSION)

--- a/src/ui/gui.py
+++ b/src/ui/gui.py
@@ -8,82 +8,17 @@
 
 
 from PyQt5 import QtCore, QtGui, QtWidgets
-from PyQt5.QtWidgets import QSystemTrayIcon, QMenu, QAction
 
-class Ui_SysTrayIndicator(object):
-    def setupSysTrayIndicator(self):
-        self.icon = QSystemTrayIcon(QtGui.QIcon(":/icons/linux_packaging/thinkfan-ui.svg"), self)
-        self.menu = QMenu()
-        self.buildSysTrayIndicatorMenu()
-        self.updateSysTrayIndicatorMenu()
-        self.icon.show()
-        self.icon.setContextMenu(self.menu)
-
-    def buildSysTrayIndicatorMenu(self):
-        self.fanSpeedMenu = QMenu(title="Fan Level:")
-        self.fanSpeedMenu.addAction("Fan Auto", lambda: self.setFanSpeed("auto"))
-        self.fanSpeedMenu.addAction("Fan Full", lambda: self.setFanSpeed("full-speed"))
-        self.fanSpeedMenu.addAction("Fan 7", lambda: self.setFanSpeed("7"))
-        self.fanSpeedMenu.addAction("Fan 6", lambda: self.setFanSpeed("6"))
-        self.fanSpeedMenu.addAction("Fan 5", lambda: self.setFanSpeed("5"))
-        self.fanSpeedMenu.addAction("Fan 4", lambda: self.setFanSpeed("4"))
-        self.fanSpeedMenu.addAction("Fan 3", lambda: self.setFanSpeed("3"))
-        self.fanSpeedMenu.addAction("Fan 2", lambda: self.setFanSpeed("2"))
-        self.fanSpeedMenu.addAction("Fan 1", lambda: self.setFanSpeed("1"))
-        self.fanSpeedMenu.addAction("Fan Off", lambda: self.setFanSpeed("0"))
-
-        self.menu.addMenu(self.fanSpeedMenu)
-        self.menu.addAction("Set Fan Auto", lambda: self.setFanSpeed("auto"))
-
-        self.menu.addSeparator()
-
-        tempInfo = self.getTempInfo()
-        for line in tempInfo.split("\n"):
-            if not line or not line.strip():
-                continue
-            temp_reading = line.replace(" ", "").replace(":", ":  ")
-            self.menu.addAction(temp_reading, self.mainWindow.appear)
-
-        self.menu.addAction(f"Fan RPM: ", self.mainWindow.appear)
-        self.menu.addAction("Quit", self.quit)
-
-    def updateSysTrayIndicatorMenu(self):
-        fan_info = self.getFanInfo()
-        if not fan_info or not fan_info.strip():
-            return
-
-        actions = {action.text().split(":")[0]: action
-                    for action in self.menu.actions()
-                    if ":" in action.text()}
-
-        tempInfo = self.getTempInfo()
-        for line in tempInfo.split("\n"):
-            if not line or not line.strip():
-                continue
-            temp_reading = line.replace(" ", "")
-            reading_name, reading_value = temp_reading.split(":")
-            if reading_name in actions:
-                actions[reading_name].setText(f"{reading_name}: {reading_value}")
-
-        for line in fan_info.split("\n"):
-            if "level:" in line:
-                fan_level = line.split("level:")[-1].strip()
-            if "speed:" in line:
-                fan_speed = line.split("speed:")[-1].strip()
-        if fan_speed and "Fan RPM" in actions:
-            actions["Fan RPM"].setText(f"Fan RPM: {fan_speed}")
-        if fan_level and "Fan Level" in actions:
-            actions["Fan Level"].setText(f"Fan Level: {fan_level}")
 
 class Ui_MainWindow(object):
-    def setupUi(self):
-        self.setObjectName("MainWindow")
-        self.resize(543, 334)
+    def setupUi(self, MainWindow):
+        MainWindow.setObjectName("MainWindow")
+        MainWindow.resize(543, 334)
         icon = QtGui.QIcon()
         icon.addPixmap(QtGui.QPixmap(":/icons/linux_packaging/thinkfan-ui.svg"), QtGui.QIcon.Normal, QtGui.QIcon.Off)
-        self.setWindowIcon(icon)
-        self.setIconSize(QtCore.QSize(32, 32))
-        self.centralwidget = QtWidgets.QWidget(self)
+        MainWindow.setWindowIcon(icon)
+        MainWindow.setIconSize(QtCore.QSize(32, 32))
+        self.centralwidget = QtWidgets.QWidget(MainWindow)
         self.centralwidget.setObjectName("centralwidget")
         self.verticalLayout = QtWidgets.QVBoxLayout(self.centralwidget)
         self.verticalLayout.setObjectName("verticalLayout")
@@ -171,19 +106,19 @@ class Ui_MainWindow(object):
         self.label_3.setTextInteractionFlags(QtCore.Qt.LinksAccessibleByKeyboard|QtCore.Qt.LinksAccessibleByMouse)
         self.label_3.setObjectName("label_3")
         self.verticalLayout.addWidget(self.label_3)
-        self.setCentralWidget(self.centralwidget)
-        self.menubar = QtWidgets.QMenuBar(self)
+        MainWindow.setCentralWidget(self.centralwidget)
+        self.menubar = QtWidgets.QMenuBar(MainWindow)
         self.menubar.setGeometry(QtCore.QRect(0, 0, 543, 34))
         self.menubar.setObjectName("menubar")
-        self.setMenuBar(self.menubar)
+        MainWindow.setMenuBar(self.menubar)
 
-        self.retranslateUi()
+        self.retranslateUi(MainWindow)
         self.slider.valueChanged['int'].connect(self.slider_value.setNum)
-        QtCore.QMetaObject.connectSlotsByName(self)
+        QtCore.QMetaObject.connectSlotsByName(MainWindow)
 
-    def retranslateUi(self):
+    def retranslateUi(self, MainWindow):
         _translate = QtCore.QCoreApplication.translate
-        self.setWindowTitle(_translate("MainWindow", "ThinkFan UI"))
+        MainWindow.setWindowTitle(_translate("MainWindow", "ThinkFan UI"))
         self.label.setText(_translate("MainWindow", "<html><head/><body><p>CPU temp info:</p></body></html>"))
         self.label_temp.setText(_translate("MainWindow", "missing data"))
         self.label_2.setText(_translate("MainWindow", "FAN info:"))

--- a/src/ui/gui.py
+++ b/src/ui/gui.py
@@ -8,23 +8,18 @@
 
 
 from PyQt5 import QtCore, QtGui, QtWidgets
-from PyQt5.QtWidgets import QSystemTrayIcon, QMenu
+from PyQt5.QtWidgets import QSystemTrayIcon, QMenu, QAction
 
 class Ui_SysTrayIndicator(object):
     def setupSysTrayIndicator(self):
         self.icon = QSystemTrayIcon(QtGui.QIcon(":/icons/linux_packaging/thinkfan-ui.svg"), self)
         self.menu = QMenu()
+        self.buildSysTrayIndicatorMenu()
         self.updateSysTrayIndicatorMenu()
         self.icon.show()
         self.icon.setContextMenu(self.menu)
 
-    def updateSysTrayIndicatorMenu(self):
-        fan_info = self.getFanInfo()
-        if not fan_info or not fan_info.strip():
-            return
-
-        for action in self.menu.actions():
-            self.menu.removeAction(action)
+    def buildSysTrayIndicatorMenu(self):
         self.menu.addAction("Fan Full", lambda: self.setFanSpeed("full-speed"))
         self.menu.addAction("Fan 7", lambda: self.setFanSpeed("7"))
         self.menu.addAction("Fan 6", lambda: self.setFanSpeed("6"))
@@ -35,19 +30,36 @@ class Ui_SysTrayIndicator(object):
         self.menu.addAction("Fan 1", lambda: self.setFanSpeed("1"))
         self.menu.addAction("Fan Off", lambda: self.setFanSpeed("0"))
         self.menu.addAction("Fan Auto", lambda: self.setFanSpeed("auto"))
-
         self.menu.addSeparator()
+
+    def updateSysTrayIndicatorMenu(self):
+        fan_info = self.getFanInfo()
+        if not fan_info or not fan_info.strip():
+            return
+
+        for action in self.menu.actions():
+            if ":" in action.text() or "Quit" in action.text() or "ThinkFan UI" in action.text():
+                self.menu.removeAction(action)
 
         tempInfo = self.getTempInfo()
         tempCount = 0
         for line in tempInfo.split("\n"):
             if not line or not line.strip():
                 continue
-            self.menu.addAction(line, self.mainWindow.appear)
+            temp_reading = line.replace(" ", "").replace(":", ":  ")
+            self.menu.addAction(temp_reading, self.mainWindow.appear)
             tempCount += 1
 
-        fan_level = fan_info.split("level:")[-1].strip()
-        self.menu.addAction(f"Fan Level: {fan_level}", self.mainWindow.appear)
+        for line in fan_info.split("\n"):
+            if "level:" in line:
+                fan_level = line.split("level:")[-1].strip()
+            if "speed:" in line:
+                fan_speed = line.split("speed:")[-1].strip()
+        if fan_speed:
+            self.menu.addAction(f"Fan RPM: {fan_speed}", self.mainWindow.appear)
+        if fan_level:
+            self.menu.addAction(f"Fan Level: {fan_level}", self.mainWindow.appear)
+
 
         if tempCount == 0:
             self.menu.addAction("ThinkFan UI", self.mainWindow.appear)

--- a/src/ui/gui.py
+++ b/src/ui/gui.py
@@ -19,6 +19,10 @@ class Ui_SysTrayIndicator(object):
         self.icon.setContextMenu(self.menu)
 
     def updateSysTrayIndicatorMenu(self):
+        fan_info = self.getFanInfo()
+        if not fan_info or not fan_info.strip():
+            return
+
         for action in self.menu.actions():
             self.menu.removeAction(action)
         self.menu.addAction("Fan Full", lambda: self.setFanSpeed("full-speed"))
@@ -32,6 +36,8 @@ class Ui_SysTrayIndicator(object):
         self.menu.addAction("Fan Off", lambda: self.setFanSpeed("0"))
         self.menu.addAction("Fan Auto", lambda: self.setFanSpeed("auto"))
 
+        self.menu.addSeparator()
+
         tempInfo = self.getTempInfo()
         tempCount = 0
         for line in tempInfo.split("\n"):
@@ -39,6 +45,10 @@ class Ui_SysTrayIndicator(object):
                 continue
             self.menu.addAction(line, self.mainWindow.appear)
             tempCount += 1
+
+        fan_level = fan_info.split("level:")[-1].strip()
+        self.menu.addAction(f"Fan Level: {fan_level}", self.mainWindow.appear)
+
         if tempCount == 0:
             self.menu.addAction("ThinkFan UI", self.mainWindow.appear)
         self.menu.addAction("Quit", self.quit)

--- a/src/ui/gui.py
+++ b/src/ui/gui.py
@@ -8,17 +8,50 @@
 
 
 from PyQt5 import QtCore, QtGui, QtWidgets
+from PyQt5.QtWidgets import QSystemTrayIcon, QMenu
 
+class Ui_SysTrayIndicator(object):
+    def setupSysTrayIndicator(self):
+        self.icon = QSystemTrayIcon(QtGui.QIcon(":/icons/linux_packaging/thinkfan-ui.svg"), self)
+        self.menu = QMenu()
+        self.updateSysTrayIndicatorMenu()
+        self.icon.show()
+        self.icon.setContextMenu(self.menu)
+
+    def updateSysTrayIndicatorMenu(self):
+        for action in self.menu.actions():
+            self.menu.removeAction(action)
+        self.menu.addAction("Fan Full", lambda: self.setFanSpeed("full-speed"))
+        self.menu.addAction("Fan 7", lambda: self.setFanSpeed("7"))
+        self.menu.addAction("Fan 6", lambda: self.setFanSpeed("6"))
+        self.menu.addAction("Fan 5", lambda: self.setFanSpeed("5"))
+        self.menu.addAction("Fan 4", lambda: self.setFanSpeed("4"))
+        self.menu.addAction("Fan 3", lambda: self.setFanSpeed("3"))
+        self.menu.addAction("Fan 2", lambda: self.setFanSpeed("2"))
+        self.menu.addAction("Fan 1", lambda: self.setFanSpeed("1"))
+        self.menu.addAction("Fan Off", lambda: self.setFanSpeed("0"))
+        self.menu.addAction("Fan Auto", lambda: self.setFanSpeed("auto"))
+
+        tempInfo = self.getTempInfo()
+        tempCount = 0
+        for line in tempInfo.split("\n"):
+            if not line or not line.strip():
+                continue
+            self.menu.addAction(line, self.mainWindow.appear)
+            tempCount += 1
+        if tempCount == 0:
+            self.menu.addAction("ThinkFan UI", self.mainWindow.appear)
+        self.menu.addAction("Quit", self.quit)
 
 class Ui_MainWindow(object):
-    def setupUi(self, MainWindow):
-        MainWindow.setObjectName("MainWindow")
-        MainWindow.resize(543, 334)
+    def setupUi(self):
+        self.setObjectName("MainWindow")
+        self.resize(543, 334)
         icon = QtGui.QIcon()
         icon.addPixmap(QtGui.QPixmap(":/icons/linux_packaging/thinkfan-ui.svg"), QtGui.QIcon.Normal, QtGui.QIcon.Off)
-        MainWindow.setWindowIcon(icon)
-        MainWindow.setIconSize(QtCore.QSize(32, 32))
-        self.centralwidget = QtWidgets.QWidget(MainWindow)
+        self.setWindowIcon(icon)
+        self.setIconSize(QtCore.QSize(32, 32))
+        self.centralwidget = QtWidgets.QWidget(self)
         self.centralwidget.setObjectName("centralwidget")
         self.verticalLayout = QtWidgets.QVBoxLayout(self.centralwidget)
         self.verticalLayout.setObjectName("verticalLayout")
@@ -106,19 +139,19 @@ class Ui_MainWindow(object):
         self.label_3.setTextInteractionFlags(QtCore.Qt.LinksAccessibleByKeyboard|QtCore.Qt.LinksAccessibleByMouse)
         self.label_3.setObjectName("label_3")
         self.verticalLayout.addWidget(self.label_3)
-        MainWindow.setCentralWidget(self.centralwidget)
-        self.menubar = QtWidgets.QMenuBar(MainWindow)
+        self.setCentralWidget(self.centralwidget)
+        self.menubar = QtWidgets.QMenuBar(self)
         self.menubar.setGeometry(QtCore.QRect(0, 0, 543, 34))
         self.menubar.setObjectName("menubar")
-        MainWindow.setMenuBar(self.menubar)
+        self.setMenuBar(self.menubar)
 
-        self.retranslateUi(MainWindow)
+        self.retranslateUi()
         self.slider.valueChanged['int'].connect(self.slider_value.setNum)
-        QtCore.QMetaObject.connectSlotsByName(MainWindow)
+        QtCore.QMetaObject.connectSlotsByName(self)
 
-    def retranslateUi(self, MainWindow):
+    def retranslateUi(self):
         _translate = QtCore.QCoreApplication.translate
-        MainWindow.setWindowTitle(_translate("MainWindow", "ThinkFan UI"))
+        self.setWindowTitle(_translate("MainWindow", "ThinkFan UI"))
         self.label.setText(_translate("MainWindow", "<html><head/><body><p>CPU temp info:</p></body></html>"))
         self.label_temp.setText(_translate("MainWindow", "missing data"))
         self.label_2.setText(_translate("MainWindow", "FAN info:"))

--- a/src/ui/systray.py
+++ b/src/ui/systray.py
@@ -1,4 +1,5 @@
 from PyQt5 import QtGui
+from PyQt5.QtCore import QTimer
 from PyQt5.QtWidgets import QSystemTrayIcon, QMenu
 
 
@@ -18,6 +19,13 @@ class QApp_SysTrayIndicator(object):
         self.updateIndicatorMenu(temp_info, fan_info)
         self.icon.setContextMenu(self.menu)
         self.icon.show()
+
+        #  aboutToShow event is fired on startup, needs to be reversed
+        onceTimer = QTimer(self)
+        onceTimer.setSingleShot(True)
+        onceTimer.timeout.connect(lambda: self.set_menu_visible(False))
+        onceTimer.start(1000)
+
 
     def set_menu_visible(self, value):
         self.menu_visible = value

--- a/src/ui/systray.py
+++ b/src/ui/systray.py
@@ -1,0 +1,67 @@
+from PyQt5 import QtGui
+from PyQt5.QtWidgets import QSystemTrayIcon, QMenu
+
+class QApp_SysTrayIndicator(object):
+    def setupSysTrayIndicator(self):
+        self.icon = QSystemTrayIcon(QtGui.QIcon(":/icons/linux_packaging/thinkfan-ui.svg"), self)
+        self.menu = QMenu()
+        self.buildSysTrayIndicatorMenu()
+        self.updateSysTrayIndicatorMenu()
+        self.icon.show()
+        self.icon.setContextMenu(self.menu)
+
+    def buildSysTrayIndicatorMenu(self):
+        self.fanSpeedMenu = QMenu(title="Fan Level:")
+        self.fanSpeedMenu.addAction("Fan Auto", lambda: self.setFanSpeed("auto"))
+        self.fanSpeedMenu.addAction("Fan Full", lambda: self.setFanSpeed("full-speed"))
+        self.fanSpeedMenu.addAction("Fan 7", lambda: self.setFanSpeed("7"))
+        self.fanSpeedMenu.addAction("Fan 6", lambda: self.setFanSpeed("6"))
+        self.fanSpeedMenu.addAction("Fan 5", lambda: self.setFanSpeed("5"))
+        self.fanSpeedMenu.addAction("Fan 4", lambda: self.setFanSpeed("4"))
+        self.fanSpeedMenu.addAction("Fan 3", lambda: self.setFanSpeed("3"))
+        self.fanSpeedMenu.addAction("Fan 2", lambda: self.setFanSpeed("2"))
+        self.fanSpeedMenu.addAction("Fan 1", lambda: self.setFanSpeed("1"))
+        self.fanSpeedMenu.addAction("Fan Off", lambda: self.setFanSpeed("0"))
+
+        self.menu.addMenu(self.fanSpeedMenu)
+        self.menu.addAction("Set Fan Auto", lambda: self.setFanSpeed("auto"))
+
+        self.menu.addSeparator()
+
+        tempInfo = self.getTempInfo()
+        for line in tempInfo.split("\n"):
+            if not line or not line.strip():
+                continue
+            temp_reading = line.replace(" ", "").replace(":", ":  ")
+            self.menu.addAction(temp_reading, self.mainWindow.appear)
+
+        self.menu.addAction(f"Fan RPM: ", self.mainWindow.appear)
+        self.menu.addAction("Quit", self.quit)
+
+    def updateSysTrayIndicatorMenu(self):
+        fan_info = self.getFanInfo()
+        if not fan_info or not fan_info.strip():
+            return
+
+        actions = {action.text().split(":")[0]: action
+                    for action in self.menu.actions()
+                    if ":" in action.text()}
+
+        tempInfo = self.getTempInfo()
+        for line in tempInfo.split("\n"):
+            if not line or not line.strip():
+                continue
+            temp_reading = line.replace(" ", "")
+            reading_name, reading_value = temp_reading.split(":")
+            if reading_name in actions:
+                actions[reading_name].setText(f"{reading_name}: {reading_value}")
+
+        for line in fan_info.split("\n"):
+            if "level:" in line:
+                fan_level = line.split("level:")[-1].strip()
+            if "speed:" in line:
+                fan_speed = line.split("speed:")[-1].strip()
+        if fan_speed and "Fan RPM" in actions:
+            actions["Fan RPM"].setText(f"Fan RPM: {fan_speed}")
+        if fan_level and "Fan Level" in actions:
+            actions["Fan Level"].setText(f"Fan Level: {fan_level}")

--- a/src/ui/systray.py
+++ b/src/ui/systray.py
@@ -5,6 +5,7 @@ from PyQt5.QtWidgets import QSystemTrayIcon, QMenu
 class QApp_SysTrayIndicator(object):
     def setupSysTrayIndicator(self):
         self.icon = QSystemTrayIcon(QtGui.QIcon(":/icons/linux_packaging/thinkfan-ui.svg"), self)
+        self.icon.activated.connect(self.mainWindow.appear)
 
         self.menu = QMenu()
         self.menu_visible = None
@@ -73,6 +74,8 @@ class QApp_SysTrayIndicator(object):
             if reading_name in actions:
                 actions[reading_name].setText(f"{reading_name}: {reading_value}")
 
+        fan_speed = None
+        fan_level = None
         for line in fan_info.split("\n"):
             if "level:" in line:
                 fan_level = line.split("level:")[-1].strip()


### PR DESCRIPTION
Hey thanks for this wrapper around the thinkfan fan control, it works great and I use it a lot.

I was finding that it was a bit much having the window open all the time though, so I set up a `QSystemTrayIcon` on my panel like so:

![image](https://user-images.githubusercontent.com/45532845/211777470-4d9ce53c-98f7-4482-a603-d716fb525afc.png)

Clicking any of the temp or fan readings will open up your main UI, or fan speeds can be set from the indicators menu without opening the main UI.

Could possibly add a couple of command line arguments to run in either mode if you would prefer.

Let me know if there's anything you want changed to get this merged.

EDIT: 
I also added in so it makes a call to pkexec to prompt for sudo password if it's needed for setting the fan speed.
This is useful as I wasn't able to run it as root without a terminal due to missing QT env arrangements.

@zocker-160 I'm not sure how to assign anyone or if you have a PR process here