### PR TITLE
Regex fix for issue #5

### DIFF
--- a/src/fan.py
+++ b/src/fan.py
@@ -112,7 +112,7 @@ class ThinkFanUI(QApplication, QApp_SysTrayIndicator):
         if not sErr:
             lines = sOut.decode().split("\n")
             result = ""
-            tempRE = re.compile(r"^(\w+):\s+\+.*(°|C|F| +)$")
+            tempRE = re.compile(r"^([\w ]+):\s+\+.*(°|C|F| +).$")
 
             for i, line in enumerate(lines):
                 line = line.strip()

--- a/src/fan.py
+++ b/src/fan.py
@@ -112,7 +112,7 @@ class ThinkFanUI(QApplication, QApp_SysTrayIndicator):
         if not sErr:
             lines = sOut.decode().split("\n")
             result = ""
-            tempRE = re.compile(r"^([\w ]+):\s+\+.*(°|C|F| +).$")
+            tempRE = re.compile(r"^([\w ]+:)\s+(\+.*)([°|C|F| +])(.)$")
 
             for i, line in enumerate(lines):
                 line = line.strip()


### PR DESCRIPTION
There was a couple of issues with the updated regex from the last PR.

I've updated it to fix issue #5 and it should catch some other edge cases as well

Confirmed fix for provided output on #5:
![image](https://user-images.githubusercontent.com/45532845/215254383-65c95d1f-c7a7-49d0-a159-021365267c24.png)


A better fix may be to use `getTempInfo_json` instead, then there doesn't have to be any regex involved, you just have to iterate through the devices and then its sensors to see which device has a sensor labelled "CPU", and filter zeroed values or such like.

I'm not sure if the slight performance hit from having to process json will make any difference or not. If you would like me to submit a PR for that I could.


