### PR TITLE
Add fallback behavior for `os.getlogin()` raising `No such device or address`

### DIFF
--- a/src/fan.py
+++ b/src/fan.py
@@ -22,8 +22,12 @@ class ThinkFanUI(QApplication, QApp_SysTrayIndicator):
 
     @staticmethod
     def updatePermissions():
-        command = ["pkexec", "chown", os.getlogin(), PROC_FAN]
-        result = subprocess.run(command)
+        try:
+            command = ["pkexec", "chown", os.getlogin(), PROC_FAN]
+            result = subprocess.run(command)
+        except OSError:
+            command = ["pkexec", "chmod", "777", PROC_FAN]
+            result = subprocess.run(command)
         print(result.returncode, result.stdout, result.stderr)
 
     @staticmethod


### PR DESCRIPTION
Add fallback behavior for `os.getlogin()` raising `No such device or address`

Apparently the behavior is depending on the environment, see here: https://bugs.python.org/issue40821

Instead I made the fan world-writable, which might not be the best security wise, but it probably good enough. Now it works for me™