### PR TITLE
add flake.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,25 @@ It is written for **Linux only**. For Windows, see [speedfan](http://www.almico.
 ### Fedora
 `sudo dnf install lm_sensors polkit python3 python3-pyqt6`
 
+### Nix (flakes)
+```bash
+# Run directly
+nix run .#
+
+# Install into user profile (desktop entry + icon included)
+nix profile install .#
+
+# Development shell
+nix develop
+python src/main.py
+```
+
+The flake provides runtime dependencies used by the app:
+- `python3` + `PyQt6`
+- `lm_sensors` (`sensors` command)
+- `polkit` (`pkexec`)
+- `xdg-utils` (`xdg-open`)
+
 ## Install
 
 ### Arch / Manjaro

--- a/README.md
+++ b/README.md
@@ -46,6 +46,35 @@ The flake provides runtime dependencies used by the app:
 - `polkit` (`pkexec`)
 - `xdg-utils` (`xdg-open`)
 
+#### NixOS note (`thinkpad_acpi`)
+
+On NixOS, you still need to enable ThinkPad fan control in the kernel module.
+Add this to your NixOS configuration:
+
+```nix
+{
+  boot.kernelModules = [ "thinkpad_acpi" ];
+  boot.extraModprobeConfig = ''
+    options thinkpad_acpi fan_control=1
+  '';
+}
+```
+
+Then run:
+
+```bash
+sudo nixos-rebuild switch
+sudo reboot
+```
+
+After reboot, verify:
+
+```bash
+cat /proc/acpi/ibm/fan
+```
+
+If `/proc/acpi/ibm/fan` is missing, your kernel/model may not support manual fan control via `thinkpad_acpi`.
+
 ## Install
 
 ### Arch / Manjaro

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771008912,
+        "narHash": "sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb+ZnAo5RzSxJg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a82ccc39b39b621151d6732718e3e250109076fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,10 @@
           name = "thinkfan-ui";
           runtimeInputs = [
             pythonEnv
+            pkgs.qt6.qtbase
+            pkgs.qt6.qtwayland
             pkgs.lm_sensors
+            pkgs.polkit
             pkgs.xdg-utils
             pkgs.coreutils
           ];
@@ -28,6 +31,10 @@
             if [ -x /run/wrappers/bin/pkexec ]; then
               export PATH="/run/wrappers/bin:$PATH"
             fi
+
+            # Ensure Qt platform plugins are visible when launching from profile/desktop.
+            export QT_PLUGIN_PATH="${pkgs.qt6.qtbase}/lib/qt-6/plugins:${pythonEnv}/${pkgs.python3.sitePackages}/PyQt6/Qt6/plugins''${QT_PLUGIN_PATH:+:$QT_PLUGIN_PATH}"
+            export QT_QPA_PLATFORM="wayland;xcb"
 
             exec python ${./src}/main.py "$@"
           '';
@@ -66,10 +73,16 @@
         devShells.default = pkgs.mkShell {
           packages = [
             pythonEnv
+            pkgs.qt6.qtbase
+            pkgs.qt6.qtwayland
             pkgs.lm_sensors
             pkgs.polkit
             pkgs.xdg-utils
           ];
+          shellHook = ''
+            export QT_PLUGIN_PATH="${pkgs.qt6.qtbase}/lib/qt-6/plugins:${pythonEnv}/${pkgs.python3.sitePackages}/PyQt6/Qt6/plugins''${QT_PLUGIN_PATH:+:$QT_PLUGIN_PATH}"
+            export QT_QPA_PLATFORM="wayland;xcb"
+          '';
         };
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,71 @@
+{
+  description = "Thinkfan UI (PyQt6)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        pythonEnv = pkgs.python3.withPackages (ps: [
+          ps.pyqt6
+        ]);
+
+        launcher = pkgs.writeShellApplication {
+          name = "thinkfan-ui";
+          runtimeInputs = [
+            pythonEnv
+            pkgs.lm_sensors
+            pkgs.polkit
+            pkgs.xdg-utils
+            pkgs.coreutils
+          ];
+          text = ''
+            exec python ${./src/main.py} "$@"
+          '';
+        };
+
+        desktopItem = pkgs.makeDesktopItem {
+          name = "thinkfan-ui";
+          desktopName = "Thinkfan UI";
+          exec = "thinkfan-ui";
+          icon = "thinkfan-ui";
+          terminal = false;
+          startupNotify = true;
+          categories = [ "System" "Utility" ];
+        };
+
+        iconFiles = pkgs.runCommandNoCC "thinkfan-ui-icons" {} ''
+          mkdir -p $out/share/icons/hicolor/scalable/apps
+          cp ${./linux_packaging/thinkfan-ui.svg} $out/share/icons/hicolor/scalable/apps/thinkfan-ui.svg
+        '';
+      in
+      {
+        packages.default = pkgs.symlinkJoin {
+          name = "thinkfan-ui";
+          paths = [
+            launcher
+            desktopItem
+            iconFiles
+          ];
+        };
+
+        apps.default = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/thinkfan-ui";
+        };
+
+        devShells.default = pkgs.mkShell {
+          packages = [
+            pythonEnv
+            pkgs.lm_sensors
+            pkgs.polkit
+            pkgs.xdg-utils
+          ];
+        };
+      });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
           categories = [ "System" "Utility" ];
         };
 
-        iconFiles = pkgs.runCommandNoCC "thinkfan-ui-icons" {} ''
+        iconFiles = pkgs.runCommand "thinkfan-ui-icons" {} ''
           mkdir -p $out/share/icons/hicolor/scalable/apps
           cp ${./linux_packaging/thinkfan-ui.svg} $out/share/icons/hicolor/scalable/apps/thinkfan-ui.svg
         '';

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
             pkgs.coreutils
           ];
           text = ''
-            exec python ${./src/main.py} "$@"
+            exec python ${./src}/main.py "$@"
           '';
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -20,11 +20,15 @@
           runtimeInputs = [
             pythonEnv
             pkgs.lm_sensors
-            pkgs.polkit
             pkgs.xdg-utils
             pkgs.coreutils
           ];
           text = ''
+            # On NixOS, pkexec must come from wrappers to keep setuid.
+            if [ -x /run/wrappers/bin/pkexec ]; then
+              export PATH="/run/wrappers/bin:$PATH"
+            fi
+
             exec python ${./src}/main.py "$@"
           '';
         };


### PR DESCRIPTION
This PR adds Nix flakes support for running and installing thinkfan-ui

### Changes
  - Added `flake.nix` with:
    - a `thinkfan-ui` package that launches `src/main.py`;
    - runtime dependencies: `python3 + PyQt6`, `lm_sensors`, `xdg-utils`, `coreutils`;
    - NixOS-friendly `pkexec` handling via `/run/wrappers/bin/pkexec`;
    - bundled desktop entry and app icon;
    - `apps.default` for `nix run`;
    - `devShells.default` for development.
  - Added `flake.lock`.
  - Updated `README.md` with:
    - usage examples for `nix run`, `nix profile install`, and `nix develop`;
    - runtime dependency list;
    - NixOS-specific note on enabling `thinkpad_acpi fan_control=1` and verifying `/proc/acpi/ibm/fan`